### PR TITLE
Java16 ladvance

### DIFF
--- a/src/app/desktop/utils/index.js
+++ b/src/app/desktop/utils/index.js
@@ -273,7 +273,7 @@ export const isLatestJavaDownloaded = async (
 
   const manifest = isJava8 ? meta.java : meta.java16;
 
-  const javaMeta = manifest.find(v => v.os === javaOs);
+  const javaMeta = manifest.find(version => version.os === javaOs);
   const javaFolder = path.join(
     userData,
     'java',

--- a/src/common/modals/JavaSetup.js
+++ b/src/common/modals/JavaSetup.js
@@ -351,7 +351,7 @@ const AutomaticSetup = () => {
         path.basename(url16).replace('.tar.gz', '.tar')
       );
 
-      const secondExtractionJava16 = extractFull(tempTarName, tempFolder, {
+      const secondExtractionJava16 = extractFull(tempTarName16, tempFolder, {
         $bin: sevenZipPath,
         $progress: true
       });

--- a/src/common/modals/JavaSetup.js
+++ b/src/common/modals/JavaSetup.js
@@ -228,6 +228,7 @@ const ManualSetup = ({ setChoice }) => {
 const AutomaticSetup = () => {
   const [downloadPercentage, setDownloadPercentage] = useState(null);
   const [currentStep, setCurrentStep] = useState('Downloading Java');
+  const [currentStepPercentage, setCurrentStepPercentage] = useState(null);
   const javaManifest = useSelector(state => state.app.javaManifest);
   const java16Manifest = useSelector(state => state.app.java16Manifest);
   const userData = useSelector(state => state.userData);
@@ -255,13 +256,17 @@ const AutomaticSetup = () => {
     const downloadLocation = path.join(tempFolder, path.basename(url));
     const downloadjava16Location = path.join(tempFolder, path.basename(url16));
 
+    setCurrentStep('Java8 - Downloading');
     await downloadFile(downloadLocation, url, p => {
       ipcRenderer.invoke('update-progress-bar', parseInt(p, 10) / 100);
       setDownloadPercentage(parseInt(p, 10));
+      setCurrentStepPercentage(p / (100 / 27.5), 10);
     });
+    setCurrentStep('Java16 - Downloading');
     await downloadFile(downloadjava16Location, url16, p => {
       ipcRenderer.invoke('update-progress-bar', parseInt(p, 10) / 100);
       setDownloadPercentage(parseInt(p, 10));
+      setCurrentStepPercentage(27.5 + p / (100 / 27.5), 10);
     });
 
     ipcRenderer.invoke('update-progress-bar', -1);
@@ -270,7 +275,7 @@ const AutomaticSetup = () => {
 
     const totalSteps = process.platform !== 'win32' ? 2 : 1;
 
-    setCurrentStep(`Extracting 1 / ${totalSteps}`);
+    setCurrentStep(`Java8 - Extracting 1 / ${totalSteps}`);
     const sevenZipPath = await get7zPath();
     const firstExtraction = extractFull(downloadLocation, tempFolder, {
       $bin: sevenZipPath,
@@ -280,6 +285,10 @@ const AutomaticSetup = () => {
       firstExtraction.on('progress', ({ percent }) => {
         ipcRenderer.invoke('update-progress-bar', percent);
         setDownloadPercentage(percent);
+        setCurrentStepPercentage(
+          27.5 + 27,
+          5 + percent / (100 / totalSteps === 2 ? 10 : 20)
+        );
       });
       firstExtraction.on('end', () => {
         resolve();
@@ -291,6 +300,7 @@ const AutomaticSetup = () => {
 
     await fse.remove(downloadLocation);
 
+    setCurrentStep(`Java16 - Extracting 1 / ${totalSteps}`);
     const firstExtractionJava16 = extractFull(
       downloadjava16Location,
       tempFolder,
@@ -304,6 +314,12 @@ const AutomaticSetup = () => {
       firstExtractionJava16.on('progress', ({ percent }) => {
         ipcRenderer.invoke('update-progress-bar', percent);
         setDownloadPercentage(percent);
+        setCurrentStepPercentage(
+          27.5 +
+            27.5 +
+            (totalSteps === 2 ? 10 : 27.5) +
+            percent / (100 / (totalSteps === 2 ? 10 : 20))
+        );
       });
       firstExtractionJava16.on('end', () => {
         resolve();
@@ -320,7 +336,7 @@ const AutomaticSetup = () => {
       ipcRenderer.invoke('update-progress-bar', -1);
       setDownloadPercentage(null);
       await new Promise(resolve => setTimeout(resolve, 500));
-      setCurrentStep(`Extracting 2 / ${totalSteps}`);
+      setCurrentStep(`Java8 - Extracting 2 / ${totalSteps}`);
 
       const tempTarName = path.join(
         tempFolder,
@@ -335,6 +351,9 @@ const AutomaticSetup = () => {
         secondExtraction.on('progress', ({ percent }) => {
           ipcRenderer.invoke('update-progress-bar', percent);
           setDownloadPercentage(percent);
+          setCurrentStepPercentage(
+            27.5 + 27.5 + 10 + 10 + percent / (100 / 10)
+          );
         });
         secondExtraction.on('end', () => {
           resolve();
@@ -346,6 +365,7 @@ const AutomaticSetup = () => {
 
       await fse.remove(tempTarName);
 
+      setCurrentStep(`Java16 - Extracting 2 / ${totalSteps}`);
       const tempTarName16 = path.join(
         tempFolder,
         path.basename(url16).replace('.tar.gz', '.tar')
@@ -359,6 +379,9 @@ const AutomaticSetup = () => {
         secondExtractionJava16.on('progress', ({ percent }) => {
           ipcRenderer.invoke('update-progress-bar', percent);
           setDownloadPercentage(percent);
+          setCurrentStepPercentage(
+            27.5 + 27.5 + 10 + 10 + 10 + percent / (100 / 10)
+          );
         });
         secondExtractionJava16.on('end', () => {
           resolve();
@@ -369,6 +392,9 @@ const AutomaticSetup = () => {
       });
       await fse.remove(tempTarName16);
     }
+
+    setCurrentStep('Cleanup');
+    setCurrentStepPercentage(95);
 
     const directoryToMove =
       process.platform === 'darwin'
@@ -410,6 +436,7 @@ const AutomaticSetup = () => {
     setCurrentStep(`Java is ready!`);
     ipcRenderer.invoke('update-progress-bar', -1);
     setDownloadPercentage(null);
+    setCurrentStepPercentage(100);
     await new Promise(resolve => setTimeout(resolve, 2000));
     dispatch(closeModal());
   };
@@ -428,6 +455,17 @@ const AutomaticSetup = () => {
         align-items: center;
       `}
     >
+      <div
+        css={`
+          margin-top: -15px; //cheaty way to get up to the Modal title :P
+          margin-bottom: 50px;
+          width: 50%;
+        `}
+      >
+        {currentStepPercentage ? (
+          <Progress percent={currentStepPercentage} showInfo={false} />
+        ) : null}
+      </div>
       <div
         css={`
           margin-bottom: 50px;


### PR DESCRIPTION
Hey Ladvance, I tested your pull for the Java16 upgrade and had some problems extracting it at first (step two, Java16) but I noticed that you forgot to rename a variable. After that it worked out great :)
If for some reason you decide not to merge this pull, just take the changes out of the fix commit and copy them (it's just line 374 JavaSetup.js).
## What is this pull?
I've created a progress bar above to provide a better overview and renamed the steps to adapt them to the new Java16 implication (e.g. so that the "Java download" doesn't take place twice).
New steps and percentages used in the progress bar:
  - [27.5%] Java8 - Download
  - [27.5%] Java16 - Downloading
  - [10/20%] Java8 - Extract 1 / x
  - [10/20%] Java16 - Extract 1 / x
  - [10%] (Java8 - Extracting 2 / x)
  - [10%] (Java16 - Extracting 2 / x)
  - [5%] clean up
  - [-] Java is ready! 
  ### Pics:
  
![Screenshot_one](https://user-images.githubusercontent.com/76821666/126361339-64a91367-7169-42d8-bbd7-7c4e8f06114e.png)
![Screenshot_two](https://user-images.githubusercontent.com/76821666/126361347-910ab528-894a-4013-838e-fafb5d92167f.png)
